### PR TITLE
Add JsonSerializable implementations

### DIFF
--- a/src/Celest/DayOfWeek.php
+++ b/src/Celest/DayOfWeek.php
@@ -106,7 +106,7 @@ use Celest\Temporal\ValueRange;
  *
  * @since 1.8
  */
-final class DayOfWeek extends AbstractTemporalAccessor implements TemporalAccessor, TemporalAdjuster
+final class DayOfWeek extends AbstractTemporalAccessor implements TemporalAccessor, TemporalAdjuster, \JsonSerializable
 {
     /**
      * @internal
@@ -585,6 +585,18 @@ final class DayOfWeek extends AbstractTemporalAccessor implements TemporalAccess
     public function __toString()
     {
         return $this->name;
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->getValue();
     }
 }
 

--- a/src/Celest/DayOfWeek.php
+++ b/src/Celest/DayOfWeek.php
@@ -588,11 +588,8 @@ final class DayOfWeek extends AbstractTemporalAccessor implements TemporalAccess
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
+     * Serialize into an ISO integer for JSON representation
+     * @return int
      */
     public function jsonSerialize()
     {

--- a/src/Celest/Duration.php
+++ b/src/Celest/Duration.php
@@ -109,7 +109,7 @@ use Celest\Temporal\UnsupportedTemporalTypeException;
  *
  * @since 1.8
  */
-final class Duration implements TemporalAmount
+final class Duration implements TemporalAmount, \JsonSerializable
 {
     /** @var Duration $ZERO */
     private static $ZERO;
@@ -1332,6 +1332,18 @@ final class Duration implements TemporalAmount
         }
         $buf .= 'S';
         return $buf;
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->__toString();
     }
 }
 

--- a/src/Celest/Duration.php
+++ b/src/Celest/Duration.php
@@ -1335,11 +1335,9 @@ final class Duration implements TemporalAmount, \JsonSerializable
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
+     * Serialize into an ISO string for JSON representation
+     * @see __toString()
+     * @return string
      */
     public function jsonSerialize()
     {

--- a/src/Celest/Instant.php
+++ b/src/Celest/Instant.php
@@ -190,7 +190,7 @@ use Celest\Temporal\ValueRange;
  *
  * @since 1.8
  */
-final class Instant extends AbstractTemporalAccessor implements Temporal, TemporalAdjuster
+final class Instant extends AbstractTemporalAccessor implements Temporal, TemporalAdjuster, \JsonSerializable
 {
     public static function init()
     {
@@ -1422,6 +1422,18 @@ final class Instant extends AbstractTemporalAccessor implements Temporal, Tempor
     }
 
 // -----------------------------------------------------------------------
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->__toString();
+    }
 }
 
 Instant::init();

--- a/src/Celest/Instant.php
+++ b/src/Celest/Instant.php
@@ -1424,11 +1424,9 @@ final class Instant extends AbstractTemporalAccessor implements Temporal, Tempor
 // -----------------------------------------------------------------------
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
+     * Serialize into an ISO string for JSON representation
+     * @see __toString()
+     * @return string
      */
     public function jsonSerialize()
     {

--- a/src/Celest/LocalDate.php
+++ b/src/Celest/LocalDate.php
@@ -117,7 +117,7 @@ use Celest\Temporal\ValueRange;
  *
  * @since 1.8
  */
-final class LocalDate extends AbstractChronoLocalDate implements Temporal, TemporalAdjuster, ChronoLocalDate
+final class LocalDate extends AbstractChronoLocalDate implements Temporal, TemporalAdjuster, ChronoLocalDate, \JsonSerializable
 {
     public static function init()
     {
@@ -2131,6 +2131,18 @@ final class LocalDate extends AbstractChronoLocalDate implements Temporal, Tempo
     static function timeLineOrder()
     {
         return AbstractChronoLocalDate::timeLineOrder();
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->__toString();
     }
 }
 

--- a/src/Celest/LocalDate.php
+++ b/src/Celest/LocalDate.php
@@ -2134,11 +2134,9 @@ final class LocalDate extends AbstractChronoLocalDate implements Temporal, Tempo
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
+     * Serialize into an ISO string for JSON representation
+     * @see __toString()
+     * @return string
      */
     public function jsonSerialize()
     {

--- a/src/Celest/LocalDateTime.php
+++ b/src/Celest/LocalDateTime.php
@@ -116,7 +116,7 @@ use Celest\Temporal\ValueRange;
  *
  * @since 1.8
  */
-final class LocalDateTime extends AbstractChronoLocalDateTime implements Temporal, TemporalAdjuster, ChronoLocalDateTime, \Serializable
+final class LocalDateTime extends AbstractChronoLocalDateTime implements Temporal, TemporalAdjuster, ChronoLocalDateTime, \Serializable, \JsonSerializable
 {
 
     public static function init()
@@ -1950,6 +1950,18 @@ final class LocalDateTime extends AbstractChronoLocalDateTime implements Tempora
         $v = explode(':', $serialized);
         $this->date = LocalDate::of((int) $v[0], (int) $v[1], (int) $v[2]);
         $this->time = LocalTime::of((int) $v[3], (int) $v[4], (int) $v[5]);
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->__toString();
     }
 }
 

--- a/src/Celest/LocalDateTime.php
+++ b/src/Celest/LocalDateTime.php
@@ -1953,11 +1953,9 @@ final class LocalDateTime extends AbstractChronoLocalDateTime implements Tempora
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
+     * Serialize into an ISO string for JSON representation
+     * @see __toString()
+     * @return string
      */
     public function jsonSerialize()
     {

--- a/src/Celest/LocalTime.php
+++ b/src/Celest/LocalTime.php
@@ -1671,11 +1671,9 @@ final class LocalTime extends AbstractTemporal implements Temporal, TemporalAdju
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
+     * Serialize into an ISO string for JSON representation
+     * @see __toString()
+     * @return string
      */
     public function jsonSerialize()
     {

--- a/src/Celest/LocalTime.php
+++ b/src/Celest/LocalTime.php
@@ -112,7 +112,7 @@ use Celest\Temporal\ValueRange;
  *
  * @since 1.8
  */
-final class LocalTime extends AbstractTemporal implements Temporal, TemporalAdjuster
+final class LocalTime extends AbstractTemporal implements Temporal, TemporalAdjuster, \JsonSerializable
 {
     /**
      * Hours per day.
@@ -1668,6 +1668,18 @@ final class LocalTime extends AbstractTemporal implements Temporal, TemporalAdju
             }
         }
         return $buf;
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->__toString();
     }
 }
 

--- a/src/Celest/Month.php
+++ b/src/Celest/Month.php
@@ -824,11 +824,8 @@ final class Month extends AbstractTemporalAccessor implements TemporalAccessor, 
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
+     * Serialize into an ISO integer for JSON representation
+     * @return int
      */
     public function jsonSerialize()
     {

--- a/src/Celest/Month.php
+++ b/src/Celest/Month.php
@@ -102,7 +102,7 @@ use Celest\Temporal\ValueRange;
  *
  * @since 1.8
  */
-final class Month extends AbstractTemporalAccessor implements TemporalAccessor, TemporalAdjuster
+final class Month extends AbstractTemporalAccessor implements TemporalAccessor, TemporalAdjuster, \JsonSerializable
 {
     /**
      * @internal
@@ -821,6 +821,18 @@ final class Month extends AbstractTemporalAccessor implements TemporalAccessor, 
     public function name()
     {
         return $this->__toString();
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->val;
     }
 }
 

--- a/src/Celest/MonthDay.php
+++ b/src/Celest/MonthDay.php
@@ -764,11 +764,9 @@ final class MonthDay extends AbstractTemporalAccessor implements TemporalAccesso
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
+     * Serialize into an ISO string for JSON representation
+     * @see __toString()
+     * @return string
      */
     public function jsonSerialize()
     {

--- a/src/Celest/MonthDay.php
+++ b/src/Celest/MonthDay.php
@@ -116,7 +116,7 @@ use Celest\Temporal\ValueRange;
  *
  * @since 1.8
  */
-final class MonthDay extends AbstractTemporalAccessor implements TemporalAccessor, TemporalAdjuster
+final class MonthDay extends AbstractTemporalAccessor implements TemporalAccessor, TemporalAdjuster, \JsonSerializable
 {
     public static function init()
     {
@@ -761,6 +761,18 @@ final class MonthDay extends AbstractTemporalAccessor implements TemporalAccesso
         return "--"
         . ($this->month < 10 ? "0" : "") . $this->month
         . ($this->day < 10 ? "-0" : "-") . $this->day;
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->__toString();
     }
 }
 

--- a/src/Celest/OffsetDateTime.php
+++ b/src/Celest/OffsetDateTime.php
@@ -1961,11 +1961,9 @@ final class OffsetDateTime extends AbstractTemporal implements Temporal, Tempora
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
+     * Serialize into an ISO string for JSON representation
+     * @see __toString()
+     * @return string
      */
     public function jsonSerialize()
     {

--- a/src/Celest/OffsetDateTime.php
+++ b/src/Celest/OffsetDateTime.php
@@ -111,7 +111,7 @@ use Celest\Temporal\ValueRange;
  *
  * @since 1.8
  */
-final class OffsetDateTime extends AbstractTemporal implements Temporal, TemporalAdjuster
+final class OffsetDateTime extends AbstractTemporal implements Temporal, TemporalAdjuster, \JsonSerializable
 {
 
     public static function init()
@@ -1958,6 +1958,18 @@ final class OffsetDateTime extends AbstractTemporal implements Temporal, Tempora
     public function __toString()
     {
         return $this->dateTime->__toString() . $this->offset->__toString();
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->__toString();
     }
 }
 

--- a/src/Celest/OffsetTime.php
+++ b/src/Celest/OffsetTime.php
@@ -1427,11 +1427,9 @@ final class OffsetTime extends AbstractTemporal implements Temporal, TemporalAdj
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
+     * Serialize into an ISO string for JSON representation
+     * @see __toString()
+     * @return string
      */
     public function jsonSerialize()
     {

--- a/src/Celest/OffsetTime.php
+++ b/src/Celest/OffsetTime.php
@@ -102,7 +102,7 @@ use Celest\Temporal\ValueRange;
  *
  * @since 1.8
  */
-final class OffsetTime extends AbstractTemporal implements Temporal, TemporalAdjuster
+final class OffsetTime extends AbstractTemporal implements Temporal, TemporalAdjuster, \JsonSerializable
 {
 
 
@@ -1424,6 +1424,18 @@ final class OffsetTime extends AbstractTemporal implements Temporal, TemporalAdj
     public function __toString()
     {
         return $this->time->__toString() . $this->offset->__toString();
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->__toString();
     }
 }
 

--- a/src/Celest/Period.php
+++ b/src/Celest/Period.php
@@ -1067,11 +1067,9 @@ final class Period implements ChronoPeriod, \JsonSerializable
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
+     * Serialize into an ISO string for JSON representation
+     * @see __toString()
+     * @return string
      */
     public function jsonSerialize()
     {

--- a/src/Celest/Period.php
+++ b/src/Celest/Period.php
@@ -119,7 +119,7 @@ use Celest\Temporal\UnsupportedTemporalTypeException;
  *
  * @since 1.8
  */
-final class Period implements ChronoPeriod
+final class Period implements ChronoPeriod, \JsonSerializable
 {
     public static function init()
     {
@@ -1064,6 +1064,18 @@ final class Period implements ChronoPeriod
             }
             return $buf;
         }
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->__toString();
     }
 }
 

--- a/src/Celest/Year.php
+++ b/src/Celest/Year.php
@@ -120,7 +120,7 @@ use Celest\Temporal\ValueRange;
  *
  * @since 1.8
  */
-final class Year extends AbstractTemporalAccessor implements Temporal, TemporalAdjuster
+final class Year extends AbstractTemporalAccessor implements Temporal, TemporalAdjuster, \JsonSerializable
 {
 
     /**
@@ -1121,4 +1121,15 @@ final class Year extends AbstractTemporalAccessor implements Temporal, TemporalA
         return Integer::toString($this->year);
     }
 
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->year;
+    }
 }

--- a/src/Celest/Year.php
+++ b/src/Celest/Year.php
@@ -1122,11 +1122,8 @@ final class Year extends AbstractTemporalAccessor implements Temporal, TemporalA
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
+     * Serialize into an ISO integer for JSON representation
+     * @return int
      */
     public function jsonSerialize()
     {

--- a/src/Celest/YearMonth.php
+++ b/src/Celest/YearMonth.php
@@ -112,7 +112,7 @@ use Celest\Temporal\ValueRange;
  *
  * @since 1.8
  */
-final class YearMonth extends AbstractTemporalAccessor implements Temporal, TemporalAdjuster
+final class YearMonth extends AbstractTemporalAccessor implements Temporal, TemporalAdjuster, \JsonSerializable
 {
     public static function init()
     {
@@ -1246,6 +1246,18 @@ final class YearMonth extends AbstractTemporalAccessor implements Temporal, Temp
         }
         return $buf . ($this->month < 10 ? "-0" : "-")
         . $this->month;
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->__toString();
     }
 }
 

--- a/src/Celest/YearMonth.php
+++ b/src/Celest/YearMonth.php
@@ -1249,11 +1249,9 @@ final class YearMonth extends AbstractTemporalAccessor implements Temporal, Temp
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
+     * Serialize into an ISO string for JSON representation
+     * @see __toString()
+     * @return string
      */
     public function jsonSerialize()
     {

--- a/src/Celest/ZonedDateTime.php
+++ b/src/Celest/ZonedDateTime.php
@@ -150,7 +150,7 @@ use Celest\Temporal\ValueRange;
  *
  * @since 1.8
  */
-final class ZonedDateTime extends AbstractChronoZonedDateTime implements Temporal, ChronoZonedDateTime
+final class ZonedDateTime extends AbstractChronoZonedDateTime implements Temporal, ChronoZonedDateTime, \JsonSerializable
 {
     /**
      * The local date-time.
@@ -2273,5 +2273,17 @@ final class ZonedDateTime extends AbstractChronoZonedDateTime implements Tempora
             $str .= '[' . $this->zone->__toString() . ']';
         }
         return $str;
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->__toString();
     }
 }

--- a/src/Celest/ZonedDateTime.php
+++ b/src/Celest/ZonedDateTime.php
@@ -2276,11 +2276,9 @@ final class ZonedDateTime extends AbstractChronoZonedDateTime implements Tempora
     }
 
     /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
+     * Serialize into an ISO string for JSON representation
+     * @see __toString()
+     * @return string
      */
     public function jsonSerialize()
     {

--- a/test/Celest/TCKDayOfWeekTest.php
+++ b/test/Celest/TCKDayOfWeekTest.php
@@ -379,6 +379,17 @@ class TCKDayOfWeekTest extends AbstractDateTimeTest
         $this->assertEquals(DayOfWeek::SUNDAY()->__toString(), "SUNDAY");
     }
 
+    public function test_jsonSerialize()
+    {
+        $this->assertEquals(json_encode(DayOfWeek::MONDAY()), 1);
+        $this->assertEquals(json_encode(DayOfWeek::TUESDAY()), 2);
+        $this->assertEquals(json_encode(DayOfWeek::WEDNESDAY()), 3);
+        $this->assertEquals(json_encode(DayOfWeek::THURSDAY()), 4);
+        $this->assertEquals(json_encode(DayOfWeek::FRIDAY()), 5);
+        $this->assertEquals(json_encode(DayOfWeek::SATURDAY()), 6);
+        $this->assertEquals(json_encode(DayOfWeek::SUNDAY()), 7);
+    }
+
     //-----------------------------------------------------------------------
     // generated methods
     //-----------------------------------------------------------------------
@@ -388,5 +399,4 @@ class TCKDayOfWeekTest extends AbstractDateTimeTest
         $this->assertEquals(DayOfWeek::valueOf("MONDAY"), DayOfWeek::MONDAY());
         $this->assertEquals(DayOfWeek::values()[0], DayOfWeek::MONDAY());
     }
-
 }

--- a/test/Celest/TCKDurationTest.php
+++ b/test/Celest/TCKDurationTest.php
@@ -2998,6 +2998,15 @@ class TCKDurationTest extends TestCase
         $this->assertEquals($t->__toString(), $expected);
     }
 
+    /**
+     * @dataProvider provider_toString
+     */
+    public function test_jsonSerialize($seconds, $nanos, $expected)
+    {
+        $t = Duration::ofSeconds($seconds, $nanos);
+        $this->assertEquals(json_decode(json_encode($t)), $expected);
+    }
+
     //-----------------------------------------------------------------------
     public function test_duration_getUnits()
     {

--- a/test/Celest/TCKInstantTest.php
+++ b/test/Celest/TCKInstantTest.php
@@ -2382,6 +2382,14 @@ class TCKInstantTest extends AbstractDateTimeTest
     /**
      * @dataProvider  data_toString
      */
+    public function test_jsonSerialize(Instant $instant, $expected)
+    {
+        $this->assertEquals($expected, json_decode(json_encode($instant)));
+    }
+
+    /**
+     * @dataProvider  data_toString
+     */
 
     public function test_parse(Instant $instant, $text)
     {

--- a/test/Celest/TCKLocalDateTest.php
+++ b/test/Celest/TCKLocalDateTest.php
@@ -2769,6 +2769,15 @@ class TCKLocalDateTest extends AbstractDateTimeTest
         $this->assertEquals($str, $expected);
     }
 
+    /**
+     * @dataProvider provider_sampleToString
+     */
+    public function test_jsonSerialize($y, $m, $d, $expected)
+    {
+        $t = LocalDate::of($y, $m, $d);
+        $this->assertEquals(json_decode(json_encode($t)), $expected);
+    }
+
     private function date($year, $month, $day)
     {
         return LocalDate::of($year, $month, $day);

--- a/test/Celest/TCKLocalDateTimeTest.php
+++ b/test/Celest/TCKLocalDateTimeTest.php
@@ -3834,6 +3834,15 @@ class TCKLocalDateTimeTest extends AbstractDateTimeTest
         $this->assertEquals($str, $expected);
     }
 
+    /**
+     * @dataProvider provider_sampleToString
+     */
+    public function test_jsonSerialize($y, $m, $d, $h, $mi, $s, $n, $expected)
+    {
+        $t = LocalDateTime::of($y, $m, $d, $h, $mi, $s, $n);
+        $this->assertEquals(json_decode(json_encode($t)), $expected);
+    }
+
     private function dtNoon($year, $month, $day)
     {
         return LocalDateTime::of($year, $month, $day, 12, 0);

--- a/test/Celest/TCKLocalTimeTest.php
+++ b/test/Celest/TCKLocalTimeTest.php
@@ -2908,6 +2908,16 @@ class TCKLocalTimeTest extends AbstractDateTimeTest
         $this->assertEquals($str, $expected);
     }
 
+    /**
+     * @dataProvider provider_sampleToString
+     */
+    public function test_jsonSerialize($h, $m, $s, $n, $expected)
+    {
+        $t = LocalTime::of($h, $m, $s, $n);
+        $str = $t->__toString();
+        $this->assertEquals(json_decode(json_encode($t)), $expected);
+    }
+
     private function time($hour, $min, $sec, $nano)
     {
         return LocalTime::of($hour, $min, $sec, $nano);

--- a/test/Celest/TCKMonthDayTest.php
+++ b/test/Celest/TCKMonthDayTest.php
@@ -902,4 +902,13 @@ class TCKMonthDayTest extends AbstractDateTimeTest
         $this->assertEquals($expected, $str);
     }
 
+    /**
+     * @dataProvider provider_sampleToString
+     */
+    public function test_jsonSerialize($m, $d, $expected)
+    {
+        $test = MonthDay::of($m, $d);
+        $this->assertEquals($expected, json_decode(json_encode($test)));
+    }
+
 }

--- a/test/Celest/TCKMonthTest.php
+++ b/test/Celest/TCKMonthTest.php
@@ -611,6 +611,22 @@ class TCKMonthTest extends AbstractDateTimeTest
         $this->assertEquals(Month::DECEMBER()->__toString(), "DECEMBER");
     }
 
+    public function test_jsonSerialize()
+    {
+        $this->assertEquals(json_encode(Month::JANUARY()), 1);
+        $this->assertEquals(json_encode(Month::FEBRUARY()), 2);
+        $this->assertEquals(json_encode(Month::MARCH()), 3);
+        $this->assertEquals(json_encode(Month::APRIL()), 4);
+        $this->assertEquals(json_encode(Month::MAY()), 5);
+        $this->assertEquals(json_encode(Month::JUNE()), 6);
+        $this->assertEquals(json_encode(Month::JULY()), 7);
+        $this->assertEquals(json_encode(Month::AUGUST()), 8);
+        $this->assertEquals(json_encode(Month::SEPTEMBER()), 9);
+        $this->assertEquals(json_encode(Month::OCTOBER()), 10);
+        $this->assertEquals(json_encode(Month::NOVEMBER()), 11);
+        $this->assertEquals(json_encode(Month::DECEMBER()), 12);
+    }
+
     //-----------------------------------------------------------------------
     // generated methods
     //-----------------------------------------------------------------------

--- a/test/Celest/TCKOffsetDateTimeTest.php
+++ b/test/Celest/TCKOffsetDateTimeTest.php
@@ -1796,4 +1796,13 @@ class TCKOffsetDateTimeTest extends AbstractDateTimeTest
         $this->assertEquals($str, $expected);
     }
 
+    /**
+     * @dataProvider provider_sampleToString
+     */
+    public function test_jsonSerialize($y, $o, $d, $h, $m, $s, $n, $offsetId, $expected)
+    {
+        $t = OffsetDateTime::of($y, $o, $d, $h, $m, $s, $n, ZoneOffset::of($offsetId));
+        $this->assertEquals(json_decode(json_encode($t)), $expected);
+    }
+
 }

--- a/test/Celest/TCKOffsetTimeTest.php
+++ b/test/Celest/TCKOffsetTimeTest.php
@@ -1605,4 +1605,13 @@ class TCKOffsetTimeTest extends AbstractDateTimeTest
         $this->assertEquals($str, $expected);
     }
 
+    /**
+     * @dataProvider provider_sampleToString
+     */
+    public function test_jsonSerializable($h, $m, $s, $n, $offsetId, $expected)
+    {
+        $t = OffsetTime::of($h, $m, $s, $n, ZoneOffset::of($offsetId));
+        $this->assertEquals(json_decode(json_encode($t)), $expected);
+    }
+
 }

--- a/test/Celest/TCKPeriodTest.php
+++ b/test/Celest/TCKPeriodTest.php
@@ -1366,6 +1366,14 @@ class TCKPeriod extends TestCase
     /**
      * @dataProvider data_toString
      */
+    public function test_jsonSerializable(Period $input, $expected)
+    {
+        $this->assertEquals(json_decode(json_encode($input)), $expected);
+    }
+
+    /**
+     * @dataProvider data_toString
+     */
     public function test_parse(Period $test, $expected)
     {
         $this->assertEquals(Period::parse($expected), $test);

--- a/test/Celest/TCKYearMonthTest.php
+++ b/test/Celest/TCKYearMonthTest.php
@@ -1718,6 +1718,15 @@ class TCKYearMonth extends AbstractDateTimeTest
         $this->assertEquals($str, $expected);
     }
 
+    /**
+     * @dataProvider provider_sampleToString
+     */
+    public function test_jsonSerializable($y, $m, $expected)
+    {
+        $test = YearMonth::of($y, $m);
+        $this->assertEquals(json_decode(json_encode($test)), $expected);
+    }
+
     private function ym($year, $month)
     {
         return YearMonth::of($year, $month);

--- a/test/Celest/TCKYearTest.php
+++ b/test/Celest/TCKYearTest.php
@@ -1301,4 +1301,13 @@ class TCKYearTest extends AbstractDateTimeTest
         }
     }
 
+    public function test_jsonSerializable()
+    {
+        for ($i = -4; $i <= 2104;
+             $i++) {
+            $a = Year::of($i);
+            $this->assertEquals(json_decode(json_encode($a)), $i);
+        }
+    }
+
 }

--- a/test/Celest/TCKZonedDateTimeTest.php
+++ b/test/Celest/TCKZonedDateTimeTest.php
@@ -2901,6 +2901,15 @@ class TCKZonedDateTimeTest extends AbstractDateTimeTest
         $this->assertEquals($str, $expected);
     }
 
+    /**
+     * @dataProvider provider_sampleToString
+     */
+    public function test_jsonSerializable($y, $o, $d, $h, $m, $s, $n, $zoneId, $expected)
+    {
+        $z = ZonedDateTime::ofDateTime($this->dateTime($y, $o, $d, $h, $m, $s, $n), ZoneId::of($zoneId));
+        $this->assertEquals(json_decode(json_encode($z)), $expected);
+    }
+
     private static function dateTime(
         $year, $month, $dayOfMonth,
         $hour, $minute, $second = 0, $nanoOfSecond = 0)


### PR DESCRIPTION
Resolves #3
I used `__toString()` everywhere, except for `Year`, `Month` and `DayOfWeek`, where I just used the integer value. Seemed sensible to me, but I'm not very opiniated about this.